### PR TITLE
Update for Rubocop 0.72.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,11 @@ Style/GuardClause:
 Style/Next:
   Enabled: false
 
+# Use older RuboCop default
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': ()
+
 # Allow explicit return with multiple return values
 Style/RedundantReturn:
   AllowMultipleReturnValues: true

--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.executables = %w[wait_up wait_up-cli]
+  s.executables = %w(wait_up wait_up-cli)
   s.files =
     Dir['bin/*', '*.md', 'LICENSE', 'Rakefile', 'Gemfile', 'lib/**/*.rb'] &
     `git ls-files -z`.split("\0")

--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
-  s.executables = ['wait_up', 'wait_up-cli']
+  s.executables = %w[wait_up wait_up-cli]
   s.files =
     Dir['bin/*', '*.md', 'LICENSE', 'Rakefile', 'Gemfile', 'lib/**/*.rb'] &
     `git ls-files -z`.split("\0")


### PR DESCRIPTION
See also https://github.com/rubocop-hq/rubocop/issues/7151.