### PR TITLE
Fix recent CI failures

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install non-ruby dependencies
       run: |
+        # Ensure all packages can be found
+        sudo apt-get update
         # Needed for gtk3 gem
         sudo apt-get install libgtk-3-dev
         # Needed for gstreamer gem
@@ -52,12 +54,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install non-ruby dependencies
       run: |
+        # Ensure all packages can be found
+        sudo apt-get update
         # Needed for gtk3 gem
         sudo apt-get install libgtk-3-dev
         # Needed for gstreamer gem
         sudo apt-get install libgstreamer1.0-dev
-        # Needed for zoom gem
-        sudo apt-get install libyaz-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Adding apt-get update ensures the package index is up-to-date so installs succeed.

Also removes the spurious installation of libyaz-dev; this gem does not use the zoom gem, so this package is not needed.
