### PR TITLE
Bump gtk3 and gstreamer dependencies

### DIFF
--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["README.md", "Changelog.md"]
 
-  spec.add_runtime_dependency "gstreamer", "~> 4.0.1"
-  spec.add_runtime_dependency "gtk3", "~> 4.0.1"
+  spec.add_runtime_dependency "gstreamer", "~> 4.1.0"
+  spec.add_runtime_dependency "gtk3", "~> 4.1.0"
 
   spec.add_development_dependency "gnome_app_driver", "~> 0.3.2"
   spec.add_development_dependency "minitest", "~> 5.12"


### PR DESCRIPTION
Version 4.1.0 is labeled as a 'bugfix release', so does not conform te semver, but avoiding version 4.0.9 is useful since it has a memory leak.
