### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["README.md", "Changelog.md"]
 
-  spec.add_runtime_dependency "gstreamer", "~> 4.2.0"
-  spec.add_runtime_dependency "gtk3", "~> 4.2.0"
+  spec.add_dependency "gstreamer", "~> 4.2.0"
+  spec.add_dependency "gtk3", "~> 4.2.0"
 
   spec.add_development_dependency "gnome_app_driver", "~> 0.3.2"
   spec.add_development_dependency "minitest", "~> 5.12"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
