### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -10,9 +10,11 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Play sound files slowly so you can follow along"
   spec.homepage = "http://www.github.com/mvz/wait_up"
-  spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
 
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.1.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = File.read("Manifest.txt").split


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
