### PR TITLE
Update RuboCop configuration and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance

--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -20,6 +20,7 @@ describe "The Wait Up application" do
     @driver.press_ctrl_q
 
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 

--- a/test/unit/pipeline_test.rb
+++ b/test/unit/pipeline_test.rb
@@ -53,12 +53,14 @@ describe WaitUp::Pipeline do
 
     it "has the correct source set up" do
       source = play_bin.source
+
       _(source.uri).must_equal "file://#{File.absolute_path filename}"
     end
   end
 
   describe "#speed_changer" do
     let(:speed_changer) { instance.speed_changer }
+
     it "returns a Gst::Element" do
       _(speed_changer).must_be_kind_of Gst::Element
     end
@@ -71,6 +73,7 @@ describe WaitUp::Pipeline do
   describe "#play" do
     it "sets the play bin's state to :playing" do
       instance.play
+
       _(instance.play_bin.get_state(0)[1]).must_equal Gst::State::PLAYING
     end
   end

--- a/wait_up.gemspec
+++ b/wait_up.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
 end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
